### PR TITLE
Fix url generator to search by filter

### DIFF
--- a/dist/linkedin/linkedin.global.page.service.js
+++ b/dist/linkedin/linkedin.global.page.service.js
@@ -46,9 +46,9 @@ class LinkedinGlobalPageService extends linkedin_abstract_service_1.LinkedinAbst
         if (parseQuery === null || parseQuery === void 0 ? void 0 : parseQuery.viewAllFilters) {
             parseQuery === null || parseQuery === void 0 ? void 0 : parseQuery.viewAllFilters = "false";
         }
-        const newUrl = (0, querystring_1.stringify)(parseQuery, onlyQuery.origin +
+        const newUrl = onlyQuery.origin +
             onlyQuery.pathname +
-            (url.indexOf("#") > -1 ? "#" : "?"));
+            (url.indexOf("#") > -1 ? "#" : "?") + querystring_1.stringify(parseQuery);
         const info = await (url.indexOf("/sales/") > -1
             ? salesPage
             : normalPage).pagesTask(page, newUrl);


### PR DESCRIPTION
There are an error when the function LinvoScraper.services.scraper.process() is called. The new URL returned it's weird and **broken**!

With this refactor the functionality works fine!

## Description
When a new url is generated by Linvo, searching using filters (https://www.linkedin.com/search/results/people?keywords=programmer), the results show a broken URL, like that:

![image](https://user-images.githubusercontent.com/58860863/210102927-b7b124d7-c182-4ea0-ab18-3c183a2d673c.png)

To solve it I just changed from the build the follow code lines:
it:
![image](https://user-images.githubusercontent.com/58860863/210103065-02f3eb43-0ba4-4e58-9507-c7735fabcac8.png)

to it:
![image](https://user-images.githubusercontent.com/58860863/210103086-be2651fb-22e6-4a74-beec-510bbabd2959.png)

and it works fine!
---
## Issue Ticket Number
Fixes #25

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/linvo-io/linvo-scraper/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes needed to the documentation